### PR TITLE
Improved logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _NCrunch_*
 **/.idea/**/contentModel.xml
 **/.idea/**/modules.xml
 .idea
+storage/

--- a/build/common.props
+++ b/build/common.props
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.6.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/common.props
+++ b/build/common.props
@@ -11,7 +11,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <ReferenceFoundatioSource Condition="$(SolutionName.Contains('All')) Or !$(SolutionName.Contains('Foundatio'))">true</ReferenceFoundatioSource>
 
-    <Copyright>Copyright (c) 2022 Foundatio.  All rights reserved.</Copyright>
+    <Copyright>Copyright (c) 2023 Foundatio.  All rights reserved.</Copyright>
     <Authors>FoundatioFx</Authors>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <WarningsAsErrors>true</WarningsAsErrors>

--- a/src/Foundatio.Storage.SshNet/Extensions/SftpExtensions.cs
+++ b/src/Foundatio.Storage.SshNet/Extensions/SftpExtensions.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 using Renci.SshNet;
 using Renci.SshNet.Sftp;
 
-namespace Foundatio.Storage {
-    internal static class SshNetExtensions {
-        public static Task<IEnumerable<SftpFile>> ListDirectoryAsync(this SftpClient client, string path, Action<int> listCallback = null) {
-            return Task.Factory.FromAsync(client.BeginListDirectory(path, null, null, listCallback), client.EndListDirectory);
-        }
+namespace Foundatio.Storage; 
+
+internal static class SshNetExtensions {
+    public static Task<IEnumerable<SftpFile>> ListDirectoryAsync(this SftpClient client, string path, Action<int> listCallback = null) {
+        return Task.Factory.FromAsync(client.BeginListDirectory(path, null, null, listCallback), client.EndListDirectory);
     }
 }

--- a/src/Foundatio.Storage.SshNet/Extensions/TaskExtensions.cs
+++ b/src/Foundatio.Storage.SshNet/Extensions/TaskExtensions.cs
@@ -4,21 +4,21 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Foundatio.AsyncEx;
 
-namespace Foundatio.Extensions {
-    internal static class TaskExtensions {
-        [DebuggerStepThrough]
-        public static ConfiguredTaskAwaitable<TResult> AnyContext<TResult>(this Task<TResult> task) {
-            return task.ConfigureAwait(continueOnCapturedContext: false);
-        }
+namespace Foundatio.Extensions; 
 
-        [DebuggerStepThrough]
-        public static ConfiguredTaskAwaitable AnyContext(this Task task) {
-            return task.ConfigureAwait(continueOnCapturedContext: false);
-        }
+internal static class TaskExtensions {
+    [DebuggerStepThrough]
+    public static ConfiguredTaskAwaitable<TResult> AnyContext<TResult>(this Task<TResult> task) {
+        return task.ConfigureAwait(continueOnCapturedContext: false);
+    }
 
-        [DebuggerStepThrough]
-        public static ConfiguredTaskAwaitable<TResult> AnyContext<TResult>(this AwaitableDisposable<TResult> task) where TResult : IDisposable {
-            return task.ConfigureAwait(continueOnCapturedContext: false);
-        }
+    [DebuggerStepThrough]
+    public static ConfiguredTaskAwaitable AnyContext(this Task task) {
+        return task.ConfigureAwait(continueOnCapturedContext: false);
+    }
+
+    [DebuggerStepThrough]
+    public static ConfiguredTaskAwaitable<TResult> AnyContext<TResult>(this AwaitableDisposable<TResult> task) where TResult : IDisposable {
+        return task.ConfigureAwait(continueOnCapturedContext: false);
     }
 }

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -13,384 +13,383 @@ using Renci.SshNet;
 using Renci.SshNet.Common;
 using Renci.SshNet.Sftp;
 
-namespace Foundatio.Storage {
-    public class SshNetFileStorage : IFileStorage {
-        private readonly ConnectionInfo _connectionInfo;
-        private readonly SftpClient _client;
-        private readonly ISerializer _serializer;
-        protected readonly ILogger _logger;
+namespace Foundatio.Storage; 
 
-        public SshNetFileStorage(SshNetFileStorageOptions options) {
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
+public class SshNetFileStorage : IFileStorage {
+    private readonly ConnectionInfo _connectionInfo;
+    private readonly SftpClient _client;
+    private readonly ISerializer _serializer;
+    protected readonly ILogger _logger;
 
-            _connectionInfo = CreateConnectionInfo(options);
-            _client = new SftpClient(_connectionInfo);
+    public SshNetFileStorage(SshNetFileStorageOptions options) {
+        if (options == null)
+            throw new ArgumentNullException(nameof(options));
 
-            _serializer = options.Serializer ?? DefaultSerializer.Instance;
-            _logger = options.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger<SshNetFileStorage>.Instance;
+        _connectionInfo = CreateConnectionInfo(options);
+        _client = new SftpClient(_connectionInfo);
+
+        _serializer = options.Serializer ?? DefaultSerializer.Instance;
+        _logger = options.LoggerFactory?.CreateLogger(GetType()) ?? NullLogger<SshNetFileStorage>.Instance;
+    }
+
+    public SshNetFileStorage(Builder<SshNetFileStorageOptionsBuilder, SshNetFileStorageOptions> config)
+        : this(config(new SshNetFileStorageOptionsBuilder()).Build()) { }
+
+    ISerializer IHaveSerializer.Serializer => _serializer;
+
+    public async Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        EnsureClientConnected();
+
+        try {
+            var stream = new MemoryStream();
+            await Task.Factory.FromAsync(_client.BeginDownloadFile(NormalizePath(path), stream, null, null), _client.EndDownloadFile).AnyContext();
+            stream.Seek(0, SeekOrigin.Begin);
+
+            return stream;
+        } catch (SftpPathNotFoundException ex) {
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace(ex, "Error trying to get file stream: {Path}", path);
+
+            return null;
+        }
+    }
+
+    public Task<FileSpec> GetFileInfoAsync(string path) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        EnsureClientConnected();
+
+        try {
+            var file = _client.Get(NormalizePath(path));
+            return Task.FromResult(new FileSpec {
+                Path = file.FullName.TrimStart('/'),
+                Created = file.LastWriteTimeUtc,
+                Modified = file.LastWriteTimeUtc,
+                Size = file.Length
+            });
+        } catch (SftpPathNotFoundException ex) {
+            if (_logger.IsEnabled(LogLevel.Trace))
+                _logger.LogTrace(ex, "Error trying to getting file info: {Path}", path);
+
+            return Task.FromResult<FileSpec>(null);
+        }
+    }
+
+    public Task<bool> ExistsAsync(string path) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        EnsureClientConnected();
+        return Task.FromResult(_client.Exists(NormalizePath(path)));
+    }
+
+    public async Task<bool> SaveFileAsync(string path, Stream stream, CancellationToken cancellationToken = default) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        if (stream == null)
+            throw new ArgumentNullException(nameof(stream));
+
+        path = NormalizePath(path);
+        EnsureClientConnected();
+
+        try {
+            await Task.Factory.FromAsync(_client.BeginUploadFile(stream, path, null, null), _client.EndUploadFile).AnyContext();
+        } catch (SftpPathNotFoundException) {
+            CreateDirectory(path);
+            await Task.Factory.FromAsync(_client.BeginUploadFile(stream, path, null, null), _client.EndUploadFile).AnyContext();
         }
 
-        public SshNetFileStorage(Builder<SshNetFileStorageOptionsBuilder, SshNetFileStorageOptions> config)
-            : this(config(new SshNetFileStorageOptionsBuilder()).Build()) { }
+        return true;
+    }
 
-        ISerializer IHaveSerializer.Serializer => _serializer;
+    public Task<bool> RenameFileAsync(string path, string newPath, CancellationToken cancellationToken = default) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+        if (String.IsNullOrEmpty(newPath))
+            throw new ArgumentNullException(nameof(newPath));
 
-        public async Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
+        newPath = NormalizePath(newPath);
+        EnsureClientConnected();
 
-            EnsureClientConnected();
-
-            try {
-                var stream = new MemoryStream();
-                await Task.Factory.FromAsync(_client.BeginDownloadFile(NormalizePath(path), stream, null, null), _client.EndDownloadFile).AnyContext();
-                stream.Seek(0, SeekOrigin.Begin);
-
-                return stream;
-            } catch (SftpPathNotFoundException ex) {
-                if (_logger.IsEnabled(LogLevel.Trace))
-                    _logger.LogTrace(ex, "Error trying to get file stream: {Path}", path);
-
-                return null;
-            }
+        try {
+            _client.RenameFile(NormalizePath(path), newPath, true);
+        } catch (SftpPathNotFoundException) {
+            CreateDirectory(newPath);
+            _client.RenameFile(NormalizePath(path), newPath, true);
         }
 
-        public Task<FileSpec> GetFileInfoAsync(string path) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
+        return Task.FromResult(true);
+    }
 
-            EnsureClientConnected();
+    public async Task<bool> CopyFileAsync(string path, string targetPath, CancellationToken cancellationToken = default) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+        if (String.IsNullOrEmpty(targetPath))
+            throw new ArgumentNullException(nameof(targetPath));
 
-            try {
-                var file = _client.Get(NormalizePath(path));
-                    return Task.FromResult(new FileSpec {
-                        Path = file.FullName.TrimStart('/'),
-                        Created = file.LastWriteTimeUtc,
-                        Modified = file.LastWriteTimeUtc,
-                        Size = file.Length
-                    });
-            } catch (SftpPathNotFoundException ex) {
-                if (_logger.IsEnabled(LogLevel.Trace))
-                    _logger.LogTrace(ex, "Error trying to getting file info: {Path}", path);
+        using var stream = await GetFileStreamAsync(path, cancellationToken).AnyContext();
+        if (stream == null)
+            return false;
 
-                return Task.FromResult<FileSpec>(null);
-            }
+        return await SaveFileAsync(targetPath, stream, cancellationToken).AnyContext();
+    }
+
+    public Task<bool> DeleteFileAsync(string path, CancellationToken cancellationToken = default) {
+        if (String.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        EnsureClientConnected();
+
+        try {
+            _client.DeleteFile(NormalizePath(path));
+        } catch (SftpPathNotFoundException ex) {
+            _logger.LogDebug(ex, "Error trying to delete file: {Path}.", path);
+            return Task.FromResult(false);
         }
 
-        public Task<bool> ExistsAsync(string path) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
+        return Task.FromResult(true);
+    }
 
-            EnsureClientConnected();
-            return Task.FromResult(_client.Exists(NormalizePath(path)));
+    public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellationToken = default) {
+        EnsureClientConnected();
+
+        if (searchPattern == null) {
+            return await DeleteDirectory("/", false);
+        } else if (searchPattern.EndsWith("/*")) {
+            return await DeleteDirectory(searchPattern.Substring(0, searchPattern.Length - 2), false);
         }
 
-        public async Task<bool> SaveFileAsync(string path, Stream stream, CancellationToken cancellationToken = default) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
+        var files = await GetFileListAsync(searchPattern, cancellationToken: cancellationToken).AnyContext();
+        int count = 0;
 
-            if (stream == null)
-                throw new ArgumentNullException(nameof(stream));
-
-            path = NormalizePath(path);
-            EnsureClientConnected();
-
-            try {
-                await Task.Factory.FromAsync(_client.BeginUploadFile(stream, path, null, null), _client.EndUploadFile).AnyContext();
-            } catch (SftpPathNotFoundException) {
-                CreateDirectory(path);
-                await Task.Factory.FromAsync(_client.BeginUploadFile(stream, path, null, null), _client.EndUploadFile).AnyContext();
-            }
-
-            return true;
+        // TODO: We could batch this, but we should ensure the batch isn't thousands of files.
+        foreach (var file in files) {
+            await DeleteFileAsync(file.Path, cancellationToken).AnyContext();
+            count++;
         }
 
-        public Task<bool> RenameFileAsync(string path, string newPath, CancellationToken cancellationToken = default) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
-            if (String.IsNullOrEmpty(newPath))
-                throw new ArgumentNullException(nameof(newPath));
+        return count;
+    }
 
-            newPath = NormalizePath(newPath);
-            EnsureClientConnected();
+    private void CreateDirectory(string path) {
+        string directory = NormalizePath(Path.GetDirectoryName(path));
+        string[] folderSegments = directory.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        string currentDirectory = String.Empty;
 
-            try {
-                _client.RenameFile(NormalizePath(path), newPath, true);
-            } catch (SftpPathNotFoundException) {
-                CreateDirectory(newPath);
-                _client.RenameFile(NormalizePath(path), newPath, true);
-            }
-
-            return Task.FromResult(true);
+        foreach (string segment in folderSegments) {
+            currentDirectory = String.Concat(currentDirectory, "/", segment);
+            if (!_client.Exists(currentDirectory))
+                _client.CreateDirectory(currentDirectory);
         }
+    }
 
-        public async Task<bool> CopyFileAsync(string path, string targetPath, CancellationToken cancellationToken = default) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
-            if (String.IsNullOrEmpty(targetPath))
-                throw new ArgumentNullException(nameof(targetPath));
+    private async Task<int> DeleteDirectory(string path, bool includeSelf) {
+        int count = 0;
 
-            using var stream = await GetFileStreamAsync(path, cancellationToken).AnyContext();
-            if (stream == null)
-                return false;
-
-            return await SaveFileAsync(targetPath, stream, cancellationToken).AnyContext();
-        }
-
-        public Task<bool> DeleteFileAsync(string path, CancellationToken cancellationToken = default) {
-            if (String.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
-
-            EnsureClientConnected();
-
-            try {
-                _client.DeleteFile(NormalizePath(path));
-            } catch (SftpPathNotFoundException ex) {
-                _logger.LogDebug(ex, "Error trying to delete file: {Path}.", path);
-                return Task.FromResult(false);
-            }
-
-            return Task.FromResult(true);
-        }
-
-        public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellationToken = default) {
-            EnsureClientConnected();
-
-            if (searchPattern == null) {
-                return await DeleteDirectory("/", false);
-            } else if (searchPattern.EndsWith("/*")) {
-                return await DeleteDirectory(searchPattern.Substring(0, searchPattern.Length - 2), false);
-            }
-
-            var files = await GetFileListAsync(searchPattern, cancellationToken: cancellationToken).AnyContext();
-            int count = 0;
-
-            // TODO: We could batch this, but we should ensure the batch isn't thousands of files.
-            foreach (var file in files) {
-                await DeleteFileAsync(file.Path, cancellationToken).AnyContext();
-                count++;
-            }
-
-            return count;
-        }
-
-        private void CreateDirectory(string path) {
-            string directory = NormalizePath(Path.GetDirectoryName(path));
-            string[] folderSegments = directory.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-            string currentDirectory = String.Empty;
-
-            foreach (string segment in folderSegments) {
-                currentDirectory = String.Concat(currentDirectory, "/", segment);
-                if (!_client.Exists(currentDirectory))
-                    _client.CreateDirectory(currentDirectory);
-            }
-        }
-
-        private async Task<int> DeleteDirectory(string path, bool includeSelf) {
-            int count = 0;
-
-            foreach (var file in await _client.ListDirectoryAsync(path)) {
-                if ((file.Name != ".") && (file.Name != "..")) {
-                    if (file.IsDirectory) {
-                        count += await DeleteDirectory(file.FullName, true);
-                    } else {
-                        _client.DeleteFile(file.FullName);
-                        count++;
-                    }
+        foreach (var file in await _client.ListDirectoryAsync(path)) {
+            if ((file.Name != ".") && (file.Name != "..")) {
+                if (file.IsDirectory) {
+                    count += await DeleteDirectory(file.FullName, true);
+                } else {
+                    _client.DeleteFile(file.FullName);
+                    count++;
                 }
             }
-
-            if (includeSelf)
-                _client.DeleteDirectory(path);
-
-            return count;
         }
 
-        public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default) {
-            if (pageSize <= 0)
-                return PagedFileListResult.Empty;
+        if (includeSelf)
+            _client.DeleteDirectory(path);
 
-            searchPattern = NormalizePath(searchPattern);
-            var result = new PagedFileListResult(r => GetFiles(searchPattern, 1, pageSize, cancellationToken));
-            await result.NextPageAsync().AnyContext();
-            return result;
+        return count;
+    }
+
+    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default) {
+        if (pageSize <= 0)
+            return PagedFileListResult.Empty;
+
+        searchPattern = NormalizePath(searchPattern);
+        var result = new PagedFileListResult(r => GetFiles(searchPattern, 1, pageSize, cancellationToken));
+        await result.NextPageAsync().AnyContext();
+        return result;
+    }
+
+    private async Task<NextPageResult> GetFiles(string searchPattern, int page, int pageSize, CancellationToken cancellationToken) {
+        int pagingLimit = pageSize;
+        int skip = (page - 1) * pagingLimit;
+        if (pagingLimit < Int32.MaxValue)
+            pagingLimit++;
+
+        var list = await GetFileListAsync(searchPattern, pagingLimit, skip, cancellationToken).AnyContext();
+        bool hasMore = false;
+        if (list.Count == pagingLimit) {
+            hasMore = true;
+            list.RemoveAt(pagingLimit - 1);
         }
 
-        private async Task<NextPageResult> GetFiles(string searchPattern, int page, int pageSize, CancellationToken cancellationToken) {
-            int pagingLimit = pageSize;
-            int skip = (page - 1) * pagingLimit;
-            if (pagingLimit < Int32.MaxValue)
-                pagingLimit++;
+        return new NextPageResult {
+            Success = true,
+            HasMore = hasMore,
+            Files = list,
+            NextPageFunc = hasMore ? r => GetFiles(searchPattern, page + 1, pageSize, cancellationToken) : null
+        };
+    }
 
-            var list = await GetFileListAsync(searchPattern, pagingLimit, skip, cancellationToken).AnyContext();
-            bool hasMore = false;
-            if (list.Count == pagingLimit) {
-                hasMore = true;
-                list.RemoveAt(pagingLimit - 1);
-            }
+    private async Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default) {
+        if (limit is <= 0)
+            return new List<FileSpec>();
 
-            return new NextPageResult {
-                Success = true,
-                HasMore = hasMore,
-                Files = list,
-                NextPageFunc = hasMore ? r => GetFiles(searchPattern, page + 1, pageSize, cancellationToken) : null
-            };
+        var list = new List<FileSpec>();
+        var criteria = GetRequestCriteria(searchPattern);
+
+        EnsureClientConnected();
+
+        // NOTE: This could be very expensive the larger the directory structure you have as we aren't efficiently doing paging.
+        int? recordsToReturn = limit.HasValue ? skip.GetValueOrDefault() * limit + limit : null;
+        await GetFileListRecursivelyAsync(criteria.Prefix, criteria.Pattern, list, recordsToReturn, cancellationToken).AnyContext();
+
+        if (skip.HasValue)
+            list = list.Skip(skip.Value).ToList();
+
+        if (limit.HasValue)
+            list = list.Take(limit.Value).ToList();
+
+        return list;
+    }
+
+    private async Task GetFileListRecursivelyAsync(string prefix, Regex pattern, ICollection<FileSpec> list, int? recordsToReturn = null, CancellationToken cancellationToken = default) {
+        _logger.LogInformation($"Checking {prefix}...");
+        if (cancellationToken.IsCancellationRequested)
+            return;
+
+        var files = new List<SftpFile>();
+        try {
+            files.AddRange(await _client.ListDirectoryAsync(prefix, null).AnyContext());
+        } catch (SftpPathNotFoundException) {
+            return;
         }
 
-        private async Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default) {
-            if (limit is <= 0)
-                return new List<FileSpec>();
-
-            var list = new List<FileSpec>();
-            var criteria = GetRequestCriteria(searchPattern);
-
-            EnsureClientConnected();
-
-            // NOTE: This could be very expensive the larger the directory structure you have as we aren't efficiently doing paging.
-            int? recordsToReturn = limit.HasValue ? skip.GetValueOrDefault() * limit + limit : null;
-            await GetFileListRecursivelyAsync(criteria.Prefix, criteria.Pattern, list, recordsToReturn, cancellationToken).AnyContext();
-
-            if (skip.HasValue)
-                list = list.Skip(skip.Value).ToList();
-
-            if (limit.HasValue)
-                list = list.Take(limit.Value).ToList();
-
-            return list;
-        }
-
-        private async Task GetFileListRecursivelyAsync(string prefix, Regex pattern, ICollection<FileSpec> list, int? recordsToReturn = null, CancellationToken cancellationToken = default) {
-            _logger.LogInformation($"Checking {prefix}...");
+        foreach (var file in files.Where(f => f.IsRegularFile || f.IsDirectory).OrderBy(f => f.IsRegularFile).ThenBy(f => f.Name)) {
             if (cancellationToken.IsCancellationRequested)
                 return;
 
-            var files = new List<SftpFile>();
-            try {
-                files.AddRange(await _client.ListDirectoryAsync(prefix, null).AnyContext());
-            } catch (SftpPathNotFoundException) {
-                return;
-            }
+            if (recordsToReturn.HasValue && list.Count >= recordsToReturn)
+                break;
 
-            foreach (var file in files.Where(f => f.IsRegularFile || f.IsDirectory).OrderBy(f => f.IsRegularFile).ThenBy(f => f.Name)) {
-                if (cancellationToken.IsCancellationRequested)
-                    return;
-
-                if (recordsToReturn.HasValue && list.Count >= recordsToReturn)
-                    break;
-
-                if (file.IsDirectory) {
-                    if (file.Name is "." or "..")
-                        continue;
-
-                    await GetFileListRecursivelyAsync(String.Concat(prefix, "/", file.Name), pattern, list, recordsToReturn, cancellationToken).AnyContext();
-                    continue;
-                }
-
-                if (!file.IsRegularFile)
+            if (file.IsDirectory) {
+                if (file.Name is "." or "..")
                     continue;
 
-                string path = file.FullName.TrimStart('/');
-                if (pattern != null && !pattern.IsMatch(path))
-                    continue;
-
-                list.Add(new FileSpec {
-                    Path = path,
-                    Created = file.LastWriteTimeUtc,
-                    Modified = file.LastWriteTimeUtc,
-                    Size = file.Length
-                });
-            }
-        }
-
-        private ConnectionInfo CreateConnectionInfo(SshNetFileStorageOptions options) {
-            if (String.IsNullOrEmpty(options.ConnectionString))
-                throw new ArgumentNullException(nameof(options.ConnectionString));
-
-            if (!Uri.TryCreate(options.ConnectionString, UriKind.Absolute, out var uri) || String.IsNullOrEmpty(uri?.UserInfo))
-                throw new ArgumentException("Unable to parse connection string uri", nameof(options.ConnectionString));
-
-            string[] userParts = uri.UserInfo.Split(new [] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-            string username = Uri.UnescapeDataString(userParts.First());
-            string password = Uri.UnescapeDataString(userParts.Length > 1 ? userParts[1] : String.Empty);
-            int port = uri.Port > 0 ? uri.Port : 22;
-
-            var authenticationMethods = new List<AuthenticationMethod>();
-            if (!String.IsNullOrEmpty(password))
-                authenticationMethods.Add(new PasswordAuthenticationMethod(username, password));
-
-            if (options.PrivateKey != null)
-                authenticationMethods.Add(new PrivateKeyAuthenticationMethod(username, new PrivateKeyFile(options.PrivateKey, options.PrivateKeyPassPhrase)));
-
-            if (authenticationMethods.Count == 0)
-                authenticationMethods.Add(new NoneAuthenticationMethod(username));
-
-            if (!String.IsNullOrEmpty(options.Proxy)) {
-                if (!Uri.TryCreate(options.Proxy, UriKind.Absolute, out var proxyUri) || String.IsNullOrEmpty(proxyUri?.UserInfo))
-                    throw new ArgumentException("Unable to parse proxy uri", nameof(options.Proxy));
-
-                string[] proxyParts = proxyUri.UserInfo.Split(new [] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-                string proxyUsername = proxyParts.First();
-                string proxyPassword = proxyParts.Length > 1 ? proxyParts[1] : null;
-
-                var proxyType = options.ProxyType;
-                if (proxyType == ProxyTypes.None && proxyUri.Scheme != null && proxyUri.Scheme.StartsWith("http"))
-                    proxyType = ProxyTypes.Http;
-
-                return new ConnectionInfo(uri.Host, port, username, proxyType, proxyUri.Host, proxyUri.Port, proxyUsername, proxyPassword, authenticationMethods.ToArray());
+                await GetFileListRecursivelyAsync(String.Concat(prefix, "/", file.Name), pattern, list, recordsToReturn, cancellationToken).AnyContext();
+                continue;
             }
 
-            return new ConnectionInfo(uri.Host, port, username, authenticationMethods.ToArray());
-        }
+            if (!file.IsRegularFile)
+                continue;
 
-        private void EnsureClientConnected() {
-            if (!_client.IsConnected)
-                _client.Connect();
-        }
+            string path = file.FullName.TrimStart('/');
+            if (pattern != null && !pattern.IsMatch(path))
+                continue;
 
-        private string NormalizePath(string path) {
-            return path?.Replace('\\', '/');
-        }
-
-        private class SearchCriteria {
-            public string Prefix { get; set; }
-            public Regex Pattern { get; set; }
-        }
-
-        private SearchCriteria GetRequestCriteria(string searchPattern) {
-            if (String.IsNullOrEmpty(searchPattern))
-                return new SearchCriteria { Prefix = String.Empty };
-
-            searchPattern = NormalizePath(searchPattern);
-            int wildcardPos = searchPattern?.IndexOf('*') ?? -1;
-            bool hasWildcard = wildcardPos >= 0;
-
-            string prefix;
-            Regex patternRegex;
-
-            if (hasWildcard) {
-                patternRegex = new Regex("^" + Regex.Escape(searchPattern).Replace("\\*", ".*?") + "$");
-                string beforeWildcard = searchPattern.Substring(0, wildcardPos);
-                int slashPos = beforeWildcard.LastIndexOf('/');
-                prefix = slashPos >= 0 ? searchPattern.Substring(0, slashPos) : String.Empty;
-            } else {
-                patternRegex = new Regex("^" + searchPattern + "$");
-                int slashPos = searchPattern.LastIndexOf('/');
-                prefix = slashPos >= 0 ? searchPattern.Substring(0, slashPos) : String.Empty;
-            }
-
-            return new SearchCriteria {
-                Prefix = prefix,
-                Pattern = patternRegex
-            };
-        }
-
-        public void Dispose() {
-            if (_client.IsConnected)
-                _client.Disconnect();
-
-            _client.Dispose();
+            list.Add(new FileSpec {
+                Path = path,
+                Created = file.LastWriteTimeUtc,
+                Modified = file.LastWriteTimeUtc,
+                Size = file.Length
+            });
         }
     }
-}
 
+    private ConnectionInfo CreateConnectionInfo(SshNetFileStorageOptions options) {
+        if (String.IsNullOrEmpty(options.ConnectionString))
+            throw new ArgumentNullException(nameof(options.ConnectionString));
+
+        if (!Uri.TryCreate(options.ConnectionString, UriKind.Absolute, out var uri) || String.IsNullOrEmpty(uri?.UserInfo))
+            throw new ArgumentException("Unable to parse connection string uri", nameof(options.ConnectionString));
+
+        string[] userParts = uri.UserInfo.Split(new [] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+        string username = Uri.UnescapeDataString(userParts.First());
+        string password = Uri.UnescapeDataString(userParts.Length > 1 ? userParts[1] : String.Empty);
+        int port = uri.Port > 0 ? uri.Port : 22;
+
+        var authenticationMethods = new List<AuthenticationMethod>();
+        if (!String.IsNullOrEmpty(password))
+            authenticationMethods.Add(new PasswordAuthenticationMethod(username, password));
+
+        if (options.PrivateKey != null)
+            authenticationMethods.Add(new PrivateKeyAuthenticationMethod(username, new PrivateKeyFile(options.PrivateKey, options.PrivateKeyPassPhrase)));
+
+        if (authenticationMethods.Count == 0)
+            authenticationMethods.Add(new NoneAuthenticationMethod(username));
+
+        if (!String.IsNullOrEmpty(options.Proxy)) {
+            if (!Uri.TryCreate(options.Proxy, UriKind.Absolute, out var proxyUri) || String.IsNullOrEmpty(proxyUri?.UserInfo))
+                throw new ArgumentException("Unable to parse proxy uri", nameof(options.Proxy));
+
+            string[] proxyParts = proxyUri.UserInfo.Split(new [] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+            string proxyUsername = proxyParts.First();
+            string proxyPassword = proxyParts.Length > 1 ? proxyParts[1] : null;
+
+            var proxyType = options.ProxyType;
+            if (proxyType == ProxyTypes.None && proxyUri.Scheme != null && proxyUri.Scheme.StartsWith("http"))
+                proxyType = ProxyTypes.Http;
+
+            return new ConnectionInfo(uri.Host, port, username, proxyType, proxyUri.Host, proxyUri.Port, proxyUsername, proxyPassword, authenticationMethods.ToArray());
+        }
+
+        return new ConnectionInfo(uri.Host, port, username, authenticationMethods.ToArray());
+    }
+
+    private void EnsureClientConnected() {
+        if (!_client.IsConnected)
+            _client.Connect();
+    }
+
+    private string NormalizePath(string path) {
+        return path?.Replace('\\', '/');
+    }
+
+    private class SearchCriteria {
+        public string Prefix { get; set; }
+        public Regex Pattern { get; set; }
+    }
+
+    private SearchCriteria GetRequestCriteria(string searchPattern) {
+        if (String.IsNullOrEmpty(searchPattern))
+            return new SearchCriteria { Prefix = String.Empty };
+
+        searchPattern = NormalizePath(searchPattern);
+        int wildcardPos = searchPattern?.IndexOf('*') ?? -1;
+        bool hasWildcard = wildcardPos >= 0;
+
+        string prefix;
+        Regex patternRegex;
+
+        if (hasWildcard) {
+            patternRegex = new Regex("^" + Regex.Escape(searchPattern).Replace("\\*", ".*?") + "$");
+            string beforeWildcard = searchPattern.Substring(0, wildcardPos);
+            int slashPos = beforeWildcard.LastIndexOf('/');
+            prefix = slashPos >= 0 ? searchPattern.Substring(0, slashPos) : String.Empty;
+        } else {
+            patternRegex = new Regex("^" + searchPattern + "$");
+            int slashPos = searchPattern.LastIndexOf('/');
+            prefix = slashPos >= 0 ? searchPattern.Substring(0, slashPos) : String.Empty;
+        }
+
+        return new SearchCriteria {
+            Prefix = prefix,
+            Pattern = patternRegex
+        };
+    }
+
+    public void Dispose() {
+        if (_client.IsConnected)
+            _client.Disconnect();
+
+        _client.Dispose();
+    }
+}

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
@@ -3,48 +3,48 @@ using System.IO;
 using System.Text;
 using Renci.SshNet;
 
-namespace Foundatio.Storage {
-    public class SshNetFileStorageOptions : SharedOptions {
-        public string ConnectionString { get; set; }
-        public string Proxy { get; set; }
-        public ProxyTypes ProxyType { get; set; }
-        public Stream PrivateKey { get; set; }
-        public string PrivateKeyPassPhrase { get; set; }
+namespace Foundatio.Storage; 
+
+public class SshNetFileStorageOptions : SharedOptions {
+    public string ConnectionString { get; set; }
+    public string Proxy { get; set; }
+    public ProxyTypes ProxyType { get; set; }
+    public Stream PrivateKey { get; set; }
+    public string PrivateKeyPassPhrase { get; set; }
+}
+
+public class SshNetFileStorageOptionsBuilder : SharedOptionsBuilder<SshNetFileStorageOptions, SshNetFileStorageOptionsBuilder> {
+    public SshNetFileStorageOptionsBuilder ConnectionString(string connectionString) {
+        Target.ConnectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+        return this;
     }
+        
+    public SshNetFileStorageOptionsBuilder Proxy(string proxy) {
+        Target.Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
+        return this;
+    }
+        
+    public SshNetFileStorageOptionsBuilder ProxyType(ProxyTypes proxyType) {
+        Target.ProxyType = proxyType;
+        return this;
+    }
+        
+        
+    public SshNetFileStorageOptionsBuilder PrivateKey(string privateKey) {
+        if (String.IsNullOrEmpty(privateKey)) 
+            throw new ArgumentNullException(nameof(privateKey));
 
-    public class SshNetFileStorageOptionsBuilder : SharedOptionsBuilder<SshNetFileStorageOptions, SshNetFileStorageOptionsBuilder> {
-        public SshNetFileStorageOptionsBuilder ConnectionString(string connectionString) {
-            Target.ConnectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
-            return this;
-        }
+        Target.PrivateKey = new MemoryStream(Encoding.UTF8.GetBytes(privateKey));
+        return this;
+    }
         
-        public SshNetFileStorageOptionsBuilder Proxy(string proxy) {
-            Target.Proxy = proxy ?? throw new ArgumentNullException(nameof(proxy));
-            return this;
-        }
+    public SshNetFileStorageOptionsBuilder PrivateKey(Stream privateKey) {
+        Target.PrivateKey = privateKey ?? throw new ArgumentNullException(nameof(privateKey));
+        return this;
+    }
         
-        public SshNetFileStorageOptionsBuilder ProxyType(ProxyTypes proxyType) {
-            Target.ProxyType = proxyType;
-            return this;
-        }
-        
-        
-        public SshNetFileStorageOptionsBuilder PrivateKey(string privateKey) {
-            if (String.IsNullOrEmpty(privateKey)) 
-                throw new ArgumentNullException(nameof(privateKey));
-
-            Target.PrivateKey = new MemoryStream(Encoding.UTF8.GetBytes(privateKey));
-            return this;
-        }
-        
-        public SshNetFileStorageOptionsBuilder PrivateKey(Stream privateKey) {
-            Target.PrivateKey = privateKey ?? throw new ArgumentNullException(nameof(privateKey));
-            return this;
-        }
-        
-        public SshNetFileStorageOptionsBuilder PrivateKeyPassPhrase(string privateKeyPassPhrase) {
-            Target.PrivateKeyPassPhrase = privateKeyPassPhrase ?? throw new ArgumentNullException(nameof(privateKeyPassPhrase));
-            return this;
-        }
+    public SshNetFileStorageOptionsBuilder PrivateKeyPassPhrase(string privateKeyPassPhrase) {
+        Target.PrivateKeyPassPhrase = privateKeyPassPhrase ?? throw new ArgumentNullException(nameof(privateKeyPassPhrase));
+        return this;
     }
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,7 +6,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1"  PrivateAssets="All" />

--- a/tests/Foundatio.Storage.SshNet.Tests/Storage/SshNetStorageTests.cs
+++ b/tests/Foundatio.Storage.SshNet.Tests/Storage/SshNetStorageTests.cs
@@ -6,135 +6,135 @@ using Foundatio.Tests.Utility;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Foundatio.SshNet.Tests.Storage {
-    [Collection("SshNetStorageIntegrationTests")]
-    public class SshNetStorageTests : FileStorageTestsBase {
-        public SshNetStorageTests(ITestOutputHelper output) : base(output) {}
+namespace Foundatio.SshNet.Tests.Storage; 
 
-        protected override IFileStorage GetStorage() {
-            string connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
-            if (String.IsNullOrEmpty(connectionString))
-                return null;
+[Collection("SshNetStorageIntegrationTests")]
+public class SshNetStorageTests : FileStorageTestsBase {
+    public SshNetStorageTests(ITestOutputHelper output) : base(output) {}
 
-            return new ScopedFileStorage(new SshNetFileStorage(o => o.ConnectionString(connectionString).LoggerFactory(Log)), "storage");
-        }
+    protected override IFileStorage GetStorage() {
+        string connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
+        if (String.IsNullOrEmpty(connectionString))
+            return null;
 
-        [Fact]
-        public void CanCreateSshNetFileStorageWithoutConnectionStringPassword() {
-            //Arrange
-            var options = new SshNetFileStorageOptionsBuilder()
-                .ConnectionString("sftp://username@host")
-                .Build();
+        return new ScopedFileStorage(new SshNetFileStorage(o => o.ConnectionString(connectionString).LoggerFactory(Log)), "storage");
+    }
+
+    [Fact]
+    public void CanCreateSshNetFileStorageWithoutConnectionStringPassword() {
+        //Arrange
+        var options = new SshNetFileStorageOptionsBuilder()
+            .ConnectionString("sftp://username@host")
+            .Build();
             
-            //Act
-            var storage = new SshNetFileStorage(options);
-        }
+        //Act
+        var storage = new SshNetFileStorage(options);
+    }
         
-        [Fact]
-        public void CanCreateSshNetFileStorageWithoutProxyPassword() {
-            //Arrange
-            var options = new SshNetFileStorageOptionsBuilder()
-                .ConnectionString("sftp://username@host")
-                .Proxy("proxy://username@host")
-                .Build();
+    [Fact]
+    public void CanCreateSshNetFileStorageWithoutProxyPassword() {
+        //Arrange
+        var options = new SshNetFileStorageOptionsBuilder()
+            .ConnectionString("sftp://username@host")
+            .Proxy("proxy://username@host")
+            .Build();
 
-            //Act
-            var storage = new SshNetFileStorage(options);
-        }
+        //Act
+        var storage = new SshNetFileStorage(options);
+    }
 
-        [Fact]
-        public override Task CanGetEmptyFileListOnMissingDirectoryAsync() {
-            return base.CanGetEmptyFileListOnMissingDirectoryAsync();
-        }
+    [Fact]
+    public override Task CanGetEmptyFileListOnMissingDirectoryAsync() {
+        return base.CanGetEmptyFileListOnMissingDirectoryAsync();
+    }
 
-        [Fact]
-        public override Task CanGetFileListForSingleFolderAsync() {
-            return base.CanGetFileListForSingleFolderAsync();
-        }
+    [Fact]
+    public override Task CanGetFileListForSingleFolderAsync() {
+        return base.CanGetFileListForSingleFolderAsync();
+    }
 
-        [Fact]
-        public override Task CanGetFileListForSingleFileAsync() {
-            return base.CanGetFileListForSingleFileAsync();
-        }
+    [Fact]
+    public override Task CanGetFileListForSingleFileAsync() {
+        return base.CanGetFileListForSingleFileAsync();
+    }
 
-        [Fact]
-        public override Task CanGetPagedFileListForSingleFolderAsync() {
-            return base.CanGetPagedFileListForSingleFolderAsync();
-        }
+    [Fact]
+    public override Task CanGetPagedFileListForSingleFolderAsync() {
+        return base.CanGetPagedFileListForSingleFolderAsync();
+    }
 
-        [Fact]
-        public override Task CanGetFileInfoAsync() {
-            return base.CanGetFileInfoAsync();
-        }
+    [Fact]
+    public override Task CanGetFileInfoAsync() {
+        return base.CanGetFileInfoAsync();
+    }
 
-        [Fact]
-        public override Task CanGetNonExistentFileInfoAsync() {
-            return base.CanGetNonExistentFileInfoAsync();
-        }
+    [Fact]
+    public override Task CanGetNonExistentFileInfoAsync() {
+        return base.CanGetNonExistentFileInfoAsync();
+    }
 
-        [Fact]
-        public override Task CanSaveFilesAsync() {
-            return base.CanSaveFilesAsync();
-        }
+    [Fact]
+    public override Task CanSaveFilesAsync() {
+        return base.CanSaveFilesAsync();
+    }
 
-        [Fact]
-        public override Task CanManageFilesAsync() {
-            return base.CanManageFilesAsync();
-        }
+    [Fact]
+    public override Task CanManageFilesAsync() {
+        return base.CanManageFilesAsync();
+    }
 
-        [Fact]
-        public override Task CanRenameFilesAsync() {
-            return base.CanRenameFilesAsync();
-        }
+    [Fact]
+    public override Task CanRenameFilesAsync() {
+        return base.CanRenameFilesAsync();
+    }
 
-        [Fact(Skip = "Doesn't work well with SFTP")]
-        public override Task CanConcurrentlyManageFilesAsync() {
-            return base.CanConcurrentlyManageFilesAsync();
-        }
+    [Fact(Skip = "Doesn't work well with SFTP")]
+    public override Task CanConcurrentlyManageFilesAsync() {
+        return base.CanConcurrentlyManageFilesAsync();
+    }
 
-        [Fact]
-        public override void CanUseDataDirectory() {
-            base.CanUseDataDirectory();
-        }
+    [Fact]
+    public override void CanUseDataDirectory() {
+        base.CanUseDataDirectory();
+    }
 
-        [Fact]
-        public override Task CanDeleteEntireFolderAsync() {
-            return base.CanDeleteEntireFolderAsync();
-        }
+    [Fact]
+    public override Task CanDeleteEntireFolderAsync() {
+        return base.CanDeleteEntireFolderAsync();
+    }
 
-        [Fact]
-        public override Task CanDeleteEntireFolderWithWildcardAsync() {
-            return base.CanDeleteEntireFolderWithWildcardAsync();
-        }
+    [Fact]
+    public override Task CanDeleteEntireFolderWithWildcardAsync() {
+        return base.CanDeleteEntireFolderWithWildcardAsync();
+    }
 
-        [Fact]
-        public override Task CanDeleteFolderWithMultiFolderWildcardsAsync() {
-            return base.CanDeleteFolderWithMultiFolderWildcardsAsync();
-        }
+    [Fact]
+    public override Task CanDeleteFolderWithMultiFolderWildcardsAsync() {
+        return base.CanDeleteFolderWithMultiFolderWildcardsAsync();
+    }
 
-        [Fact]
-        public override Task CanDeleteSpecificFilesAsync() {
-            return base.CanDeleteSpecificFilesAsync();
-        }
+    [Fact]
+    public override Task CanDeleteSpecificFilesAsync() {
+        return base.CanDeleteSpecificFilesAsync();
+    }
 
-        [Fact]
-        public override Task CanDeleteNestedFolderAsync() {
-            return base.CanDeleteNestedFolderAsync();
-        }
+    [Fact]
+    public override Task CanDeleteNestedFolderAsync() {
+        return base.CanDeleteNestedFolderAsync();
+    }
 
-        [Fact]
-        public override Task CanDeleteSpecificFilesInNestedFolderAsync() {
-            return base.CanDeleteSpecificFilesInNestedFolderAsync();
-        }
+    [Fact]
+    public override Task CanDeleteSpecificFilesInNestedFolderAsync() {
+        return base.CanDeleteSpecificFilesInNestedFolderAsync();
+    }
 
-        [Fact]
-        public override Task CanRoundTripSeekableStreamAsync() {
-            return base.CanRoundTripSeekableStreamAsync();
-        }
+    [Fact]
+    public override Task CanRoundTripSeekableStreamAsync() {
+        return base.CanRoundTripSeekableStreamAsync();
+    }
 
-        [Fact]
-        public override Task WillRespectStreamOffsetAsync() {
-            return base.WillRespectStreamOffsetAsync();
-        }
+    [Fact]
+    public override Task WillRespectStreamOffsetAsync() {
+        return base.WillRespectStreamOffsetAsync();
     }
 }


### PR DESCRIPTION
It was hard to track down what the client was doing especially around getting file lists.

Turning on trace logs in `CanGetFileInfoAsync` returns

```
38:53.18633 I:SshNetStorageTests - Deleting all files...
38:53.19180 T:SshNetFileStorage - Connecting to localhost:2222
38:54.68971 T:SshNetFileStorage - Connected to localhost:2222
38:54.69036 T:SshNetFileStorage - Deleting storage/data directory
38:54.70279 T:SshNetFileStorage - Deleting file /storage/data/Foundatio.Tests.csproj
38:54.70615 I:SshNetStorageTests - Asserting empty files...
38:54.71156 T:SshNetFileStorage - Getting file list recursively matching storage/data...
38:54.72019 T:SshNetFileStorage - Getting file info for storage/data/6a0d8a37-e69a-4065-ba77-f9dee9df83ae
38:54.72430 D:SshNetFileStorage - Unable to get file info for storage/data/6a0d8a37-e69a-4065-ba77-f9dee9df83ae: File Not Found
38:54.72522 T:SshNetFileStorage - Saving storage/data/folder/202b7ecf-90f1-464c-af49-658c58c11073-nested.txt
38:54.73226 D:SshNetFileStorage - Error saving storage/data/folder/202b7ecf-90f1-464c-af49-658c58c11073-nested.txt: Attempting to create directory
38:54.73243 T:SshNetFileStorage - Ensuring storage/data/folder directory exists
38:54.73705 T:SshNetFileStorage - Creating storage/data/folder directory
38:54.74090 T:SshNetFileStorage - Saving storage/data/folder/202b7ecf-90f1-464c-af49-658c58c11073-nested.txt
38:54.74686 T:SshNetFileStorage - Getting file info for storage/data/folder/202b7ecf-90f1-464c-af49-658c58c11073-nested.txt
38:54.75060 T:SshNetFileStorage - Saving storage/data/485503d9-065f-4471-8fc5-477f375e1eb3-test.txt
38:54.75570 T:SshNetFileStorage - Getting file info for storage/data/485503d9-065f-4471-8fc5-477f375e1eb3-test.txt
````