### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>

--- a/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
+++ b/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
+++ b/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
+++ b/src/Foundatio.Storage.SshNet/Foundatio.Storage.SshNet.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -270,7 +270,7 @@ public class SshNetFileStorage : IFileStorage
 
     private void CreateDirectory(string path)
     {
-        string directory = NormalizePath(Path.GetDirectoryName(path) ?? string.Empty);
+        string directory = NormalizePath(Path.GetDirectoryName(path) ?? String.Empty);
         _logger.LogTrace("Ensuring {Directory} directory exists", directory);
 
         string[] folderSegments = directory?.Split(['/'], StringSplitOptions.RemoveEmptyEntries) ?? [];
@@ -518,7 +518,7 @@ public class SshNetFileStorage : IFileStorage
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; } = string.Empty;
+        public string Prefix { get; set; } = String.Empty;
         public Regex? Pattern { get; set; }
     }
 

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -44,10 +44,10 @@ public class SshNetFileStorage : IFileStorage
     }
 
     [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
-    public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
+    public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-    public async Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
+    public async Task<Stream?> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -81,7 +81,7 @@ public class SshNetFileStorage : IFileStorage
         }
     }
 
-    public Task<FileSpec> GetFileInfoAsync(string path)
+    public Task<FileSpec?> GetFileInfoAsync(string path)
     {
         if (String.IsNullOrEmpty(path))
             throw new ArgumentNullException(nameof(path));
@@ -95,9 +95,9 @@ public class SshNetFileStorage : IFileStorage
         {
             var file = _client.Get(normalizedPath);
             if (file.IsDirectory)
-                return Task.FromResult<FileSpec>(null);
+                return Task.FromResult<FileSpec?>(null);
 
-            return Task.FromResult(new FileSpec
+            return Task.FromResult<FileSpec?>(new FileSpec
             {
                 Path = normalizedPath,
                 Created = file.LastWriteTimeUtc,
@@ -108,7 +108,7 @@ public class SshNetFileStorage : IFileStorage
         catch (SftpPathNotFoundException ex)
         {
             _logger.LogError(ex, "Unable to get file info for {Path}: File Not Found", normalizedPath);
-            return Task.FromResult<FileSpec>(null);
+            return Task.FromResult<FileSpec?>(null);
         }
     }
 
@@ -243,7 +243,7 @@ public class SshNetFileStorage : IFileStorage
         return true;
     }
 
-    public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<int> DeleteFilesAsync(string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         EnsureClientConnected();
 
@@ -270,7 +270,7 @@ public class SshNetFileStorage : IFileStorage
 
     private void CreateDirectory(string path)
     {
-        string directory = NormalizePath(Path.GetDirectoryName(path));
+        string directory = NormalizePath(Path.GetDirectoryName(path) ?? string.Empty);
         _logger.LogTrace("Ensuring {Directory} directory exists", directory);
 
         string[] folderSegments = directory?.Split(['/'], StringSplitOptions.RemoveEmptyEntries) ?? [];
@@ -330,7 +330,7 @@ public class SshNetFileStorage : IFileStorage
         return count;
     }
 
-    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         if (pageSize <= 0)
             return PagedFileListResult.Empty;
@@ -340,7 +340,7 @@ public class SshNetFileStorage : IFileStorage
         return result;
     }
 
-    private async Task<NextPageResult> GetFiles(string searchPattern, int page, int pageSize, CancellationToken cancellationToken)
+    private async Task<NextPageResult> GetFiles(string? searchPattern, int page, int pageSize, CancellationToken cancellationToken)
     {
         int pagingLimit = pageSize;
         int skip = (page - 1) * pagingLimit;
@@ -364,7 +364,7 @@ public class SshNetFileStorage : IFileStorage
         };
     }
 
-    private async Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
+    private async Task<List<FileSpec>> GetFileListAsync(string? searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
     {
         if (limit is <= 0)
             return new List<FileSpec>();
@@ -378,8 +378,8 @@ public class SshNetFileStorage : IFileStorage
         int? recordsToReturn = limit.HasValue ? skip.GetValueOrDefault() * limit + limit : null;
 
         _logger.LogTrace(
-            s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
-            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
+            s => s.Property("SearchPattern", searchPattern ?? "(none)").Property("Limit", limit?.ToString() ?? "(none)").Property("Skip", skip?.ToString() ?? "(none)"),
+            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern?.ToString() ?? "(none)"
         );
 
         await GetFileListRecursivelyAsync(criteria.Prefix, criteria.Pattern, list, recordsToReturn, cancellationToken).AnyContext();
@@ -393,7 +393,7 @@ public class SshNetFileStorage : IFileStorage
         return list;
     }
 
-    private async Task GetFileListRecursivelyAsync(string prefix, Regex pattern, ICollection<FileSpec> list, int? recordsToReturn = null, CancellationToken cancellationToken = default)
+    private async Task GetFileListRecursivelyAsync(string prefix, Regex? pattern, ICollection<FileSpec> list, int? recordsToReturn = null, CancellationToken cancellationToken = default)
     {
         if (cancellationToken.IsCancellationRequested)
         {
@@ -489,7 +489,7 @@ public class SshNetFileStorage : IFileStorage
 
             string[] proxyParts = proxyUri.UserInfo.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
             string proxyUsername = proxyParts.First();
-            string proxyPassword = proxyParts.Length > 1 ? proxyParts[1] : null;
+            string? proxyPassword = proxyParts.Length > 1 ? proxyParts[1] : null;
 
             var proxyType = options.ProxyType;
             if (proxyType == ProxyTypes.None && proxyUri.Scheme != null && proxyUri.Scheme.StartsWith("http"))
@@ -513,16 +513,16 @@ public class SshNetFileStorage : IFileStorage
 
     private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private class SearchCriteria
     {
-        public string Prefix { get; set; }
-        public Regex Pattern { get; set; }
+        public string Prefix { get; set; } = string.Empty;
+        public Regex? Pattern { get; set; }
     }
 
-    private SearchCriteria GetRequestCriteria(string searchPattern)
+    private SearchCriteria GetRequestCriteria(string? searchPattern)
     {
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -245,6 +245,9 @@ public class SshNetFileStorage : IFileStorage
 
     public async Task<int> DeleteFilesAsync(string? searchPattern = null, CancellationToken cancellationToken = default)
     {
+        if (String.IsNullOrEmpty(searchPattern))
+            searchPattern = null;
+
         EnsureClientConnected();
 
         if (searchPattern == null)

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -270,10 +270,14 @@ public class SshNetFileStorage : IFileStorage
 
     private void CreateDirectory(string path)
     {
-        string? directory = NormalizePath(Path.GetDirectoryName(path));
+        string? directoryName = Path.GetDirectoryName(path);
+        if (String.IsNullOrEmpty(directoryName))
+            return;
+
+        string directory = NormalizePath(directoryName);
         _logger.LogTrace("Ensuring {Directory} directory exists", directory);
 
-        string[] folderSegments = directory?.Split(['/'], StringSplitOptions.RemoveEmptyEntries) ?? [];
+        string[] folderSegments = directory.Split(['/'], StringSplitOptions.RemoveEmptyEntries);
         string currentDirectory = String.Empty;
 
         foreach (string segment in folderSegments)
@@ -511,10 +515,9 @@ public class SshNetFileStorage : IFileStorage
         _logger.LogTrace("Connected to {Host}:{Port} in {WorkingDirectory}", _client.ConnectionInfo.Host, _client.ConnectionInfo.Port, _client.WorkingDirectory);
     }
 
-    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(path))]
-    private string? NormalizePath(string? path)
+    private string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private record SearchCriteria

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorage.cs
@@ -43,7 +43,7 @@ public class SshNetFileStorage : IFileStorage
         return _client;
     }
 
-    [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(FileAccess)} instead to define read or write behaviour of stream")]
+    [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(StreamMode)} instead to define read or write behaviour of stream")]
     public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
@@ -270,7 +270,7 @@ public class SshNetFileStorage : IFileStorage
 
     private void CreateDirectory(string path)
     {
-        string directory = NormalizePath(Path.GetDirectoryName(path) ?? String.Empty);
+        string? directory = NormalizePath(Path.GetDirectoryName(path));
         _logger.LogTrace("Ensuring {Directory} directory exists", directory);
 
         string[] folderSegments = directory?.Split(['/'], StringSplitOptions.RemoveEmptyEntries) ?? [];
@@ -378,8 +378,8 @@ public class SshNetFileStorage : IFileStorage
         int? recordsToReturn = limit.HasValue ? skip.GetValueOrDefault() * limit + limit : null;
 
         _logger.LogTrace(
-            s => s.Property("SearchPattern", searchPattern ?? "(none)").Property("Limit", limit?.ToString() ?? "(none)").Property("Skip", skip?.ToString() ?? "(none)"),
-            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern?.ToString() ?? "(none)"
+            s => s.Property("SearchPattern", searchPattern).Property("Limit", limit).Property("Skip", skip),
+            "Getting file list recursively matching {Prefix} and {Pattern}...", criteria.Prefix, criteria.Pattern
         );
 
         await GetFileListRecursivelyAsync(criteria.Prefix, criteria.Pattern, list, recordsToReturn, cancellationToken).AnyContext();
@@ -511,15 +511,16 @@ public class SshNetFileStorage : IFileStorage
         _logger.LogTrace("Connected to {Host}:{Port} in {WorkingDirectory}", _client.ConnectionInfo.Host, _client.ConnectionInfo.Port, _client.WorkingDirectory);
     }
 
-    private string NormalizePath(string path)
+    [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNull(nameof(path))]
+    private string? NormalizePath(string? path)
     {
-        return path.Replace('\\', '/');
+        return path?.Replace('\\', '/');
     }
 
-    private class SearchCriteria
+    private record SearchCriteria
     {
-        public string Prefix { get; set; } = String.Empty;
-        public Regex? Pattern { get; set; }
+        public required string Prefix { get; init; }
+        public Regex? Pattern { get; init; }
     }
 
     private SearchCriteria GetRequestCriteria(string? searchPattern)

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
@@ -7,11 +7,11 @@ namespace Foundatio.Storage;
 
 public class SshNetFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; }
-    public string Proxy { get; set; }
+    public string ConnectionString { get; set; } = null!;
+    public string? Proxy { get; set; }
     public ProxyTypes ProxyType { get; set; }
-    public Stream PrivateKey { get; set; }
-    public string PrivateKeyPassPhrase { get; set; }
+    public Stream? PrivateKey { get; set; }
+    public string? PrivateKeyPassPhrase { get; set; }
 }
 
 public class SshNetFileStorageOptionsBuilder : SharedOptionsBuilder<SshNetFileStorageOptions, SshNetFileStorageOptionsBuilder>

--- a/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
+++ b/src/Foundatio.Storage.SshNet/Storage/SshNetFileStorageOptions.cs
@@ -7,7 +7,7 @@ namespace Foundatio.Storage;
 
 public class SshNetFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
     public string? Proxy { get; set; }
     public ProxyTypes ProxyType { get; set; }
     public Stream? PrivateKey { get; set; }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.43" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.Storage.SshNet.Tests/Storage/RootedSshNetStorageTests.cs
+++ b/tests/Foundatio.Storage.SshNet.Tests/Storage/RootedSshNetStorageTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Foundatio.Storage;
 using Foundatio.Tests.Storage;
@@ -12,9 +12,9 @@ public class RootedSshNetStorageTests : FileStorageTestsBase
 {
     public RootedSshNetStorageTests(ITestOutputHelper output) : base(output) { }
 
-    protected override IFileStorage GetStorage()
+    protected override IFileStorage? GetStorage()
     {
-        string connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return null;
 

--- a/tests/Foundatio.Storage.SshNet.Tests/Storage/SshNetStorageTests.cs
+++ b/tests/Foundatio.Storage.SshNet.Tests/Storage/SshNetStorageTests.cs
@@ -12,9 +12,9 @@ public class SshNetStorageTests : FileStorageTestsBase
 {
     public SshNetStorageTests(ITestOutputHelper output) : base(output) { }
 
-    protected override IFileStorage GetStorage()
+    protected override IFileStorage? GetStorage()
     {
-        string connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("SshNetStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return null;
 


### PR DESCRIPTION
## Summary
- Replaced ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ with correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed nullable arguments in LogState.Property calls

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors